### PR TITLE
Added execution of secure channel key exchange, macsec and batman

### DIFF
--- a/socket/python3/auth/authClient.py
+++ b/socket/python3/auth/authClient.py
@@ -4,7 +4,7 @@ import sys
 sys.path.insert(0, '../')
 from tools.verification_tools import *
 from tools.custom_logger import CustomLogger
-from tools.utils import mac_to_ipv6
+from tools.utils import mac_to_ipv6, get_mac_addr
 import glob
 import random
 import time
@@ -25,6 +25,7 @@ class AuthClient:
         self.secure_client_socket = None
         self.logger = self._setup_logger()
         self.ca = f'{self.CERT_PATH}/ca.crt'
+        self.mymac = get_mac_addr(self.interface)
 
     @staticmethod
     def _setup_logger():

--- a/socket/python3/auth/authServer.py
+++ b/socket/python3/auth/authServer.py
@@ -47,7 +47,6 @@ class AuthServer:
             auth = verify_cert(client_cert, self.ca, client_address[0], logger)
             with self.client_auth_results_lock:
                 self.client_auth_results[client_address[0]] = auth
-            print("Debug: client_auth_results: ", self.client_auth_results)
             if auth:
                 with self.active_sockets_lock:
                     self.active_sockets[client_address[0]] = secure_client_socket

--- a/socket/python3/auth/authServer.py
+++ b/socket/python3/auth/authServer.py
@@ -1,7 +1,7 @@
 import socket
 import ssl
 import threading
-from tools.utils import is_ipv4, is_ipv6
+from tools.utils import *
 import sys
 
 sys.path.insert(0, '../')
@@ -22,6 +22,7 @@ class AuthServer:
         self.CERT_PATH = cert_path
         self.ca = f'{self.CERT_PATH}/ca.crt'
         self.interface = "wlp1s0"
+        self.mymac = get_mac_addr(self.interface)
         # Create the SSL context here and set it as an instance variable
         self.context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
         self.context.verify_mode = ssl.CERT_REQUIRED
@@ -32,6 +33,9 @@ class AuthServer:
         )
         self.client_auth_results = {}
         self.active_sockets = {}
+        self.client_auth_results_lock = threading.Lock()
+        self.active_sockets_lock = threading.Lock()
+
 
     def handle_client(self, secure_client_socket, client_address):
         try:
@@ -41,9 +45,17 @@ class AuthServer:
                 raise CertificateNoPresentError("Unable to get the certificate from the client")
 
             auth = verify_cert(client_cert, self.ca, client_address[0], logger)
-            self.client_auth_results[client_address[0]] = auth
+            with self.client_auth_results_lock:
+                self.client_auth_results[client_address[0]] = auth
+            print("Debug: client_auth_results: ", self.client_auth_results)
             if auth:
-                self.active_sockets[client_address[0]] = secure_client_socket
+                with self.active_sockets_lock:
+                    self.active_sockets[client_address[0]] = secure_client_socket
+                #self.setup_macsec_mesh(secure_client_socket, client_address)
+                setup_macsec_mesh(role="primary",
+                                  secure_client_socket=secure_client_socket,
+                                  my_mac=self.mymac,
+                                  client_mac=extract_mac_from_ipv6(client_address[0]))
             else:
                 # Handle the case when authentication fails, maybe send an error message
                 secure_client_socket.send(b"Authentication failed.")
@@ -53,10 +65,12 @@ class AuthServer:
         #     secure_client_socket.close()
 
     def get_secure_socket(self, client_address):
-        return self.active_sockets.get(client_address)
+        with self.active_sockets_lock:
+            return self.active_sockets.get(client_address)
 
     def get_client_auth_result(self, client_address):
-        return self.client_auth_results.get(client_address, None)
+        with self.client_auth_results_lock:
+            return self.client_auth_results.get(client_address, None)
 
     def start_server(self):
         if is_ipv4(self.ipAddress):
@@ -97,7 +111,6 @@ class AuthServer:
             self.serverSocket.close()
             for sock in auth_server.active_sockets.values():
                 sock.close()
-
 
 if __name__ == "__main__":
     # IP address and the port number of the server

--- a/socket/python3/cert_generation/ca_side.py
+++ b/socket/python3/cert_generation/ca_side.py
@@ -60,7 +60,7 @@ def generate_and_send_certificates(csr_filename, IPAddress):
         logger.info("Certificates sent successfully.")
     except Exception as e:
         logger.error(f"Error generating and sending certificates: {e}")
-    raise
+        raise
 
     # Clean up
     # os.remove(crt_filename)

--- a/socket/python3/macsec/macsec.py
+++ b/socket/python3/macsec/macsec.py
@@ -1,0 +1,24 @@
+import subprocess
+import sys
+import os
+
+script_dir = os.path.dirname(__file__) # path to macsec directory
+class Macsec:
+    def __init__(self, role, key1, key2, mac_prim, mac_seco, interface='wlp1s0', status='up'):
+        self.interface = interface
+        self.status = status
+        self.role = role
+        self.key1 = key1
+        self.key2 = key2
+        self.mac_prim = mac_prim
+        self.mac_seco = mac_seco
+        self.macsec_encryption = "off" # Flag to set macsec encrypt on or off
+
+    def run_macsec(self):
+        try:
+            # Replace 'run_macsec.sh' with the actual path to your bash script
+            script_path = f'{script_dir}/setmacsec.sh'
+            subprocess.run([script_path] + [self.interface, self.status, self.macsec_encryption, self.role, self.key1, self.key2, self.mac_prim, self.mac_seco], check=True)
+        except subprocess.CalledProcessError as e:
+            print(f"Error executing the script: {e}")
+            sys.exit(1)

--- a/socket/python3/macsec/setmacsec.sh
+++ b/socket/python3/macsec/setmacsec.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-### This command should be executed as ./run_macsec.sh <up/down> <interface> <primary/secondary>
+### This command should be executed as ./run_macsec.sh <interface> <up/down> <encryption on/off> <primary/secondary> <key1> <key2> <mac primary> <mac secondary>
 ### up is to set the interface up
 ### primary means the first node that will be running (will get the key1
 ###
@@ -10,15 +10,14 @@ configure_mac_sec()
 
   echo "configuring MacSec"
 
-  source variables.conf
-        interface=$INTERFACE
-        status=$STATUS
-        role=$ROLE
-        key1=$KEY1
-        #key2=$(echo "$key1" | rev);
-        key2=$KEY2
-        macprim=$MACPRIM
-        macseco=$MACSECO
+  interface=$1
+  status=$2
+  encryption=$3
+  role=$4
+  key1=$5
+  key2=$6
+  macprim=$7
+  macseco=$8
 
   get_mac()
   {
@@ -29,14 +28,14 @@ configure_mac_sec()
   {
   echo "$interface"
   mac=$(get_mac "$interface")
-  ip link del link "$interface" macsec0 type macsec encrypt on
+  ip link del link "$interface" macsec0 type macsec encrypt "$encryption"
   }
 
   up()
   {
   echo "here"
   ip link set "$interface" up
-  ip link add link "$interface" macsec0 type macsec encrypt on
+  ip link add link "$interface" macsec0 type macsec encrypt "$encryption"
 
   if [[ "$role" == "primary" ]]
   then
@@ -49,9 +48,9 @@ configure_mac_sec()
     ip macsec add macsec0 rx port 1 address "$macprim" sa 0 pn 1 on key 02 "$key1"
   fi
   ip link set macsec0 up
-  ipa=$(( ( RANDOM % 100 )  + 1 ))
-  ip addr add 10.10.10.$ipa/24 dev macsec0
-  echo "IP: 10.10.10.$ipa/24"
+  #ipa=$(( ( RANDOM % 100 )  + 1 ))
+  #ip addr add 10.10.10.$ipa/24 dev macsec0
+  #echo "IP: 10.10.10.$ipa/24"
   }
 
 
@@ -66,5 +65,5 @@ configure_mac_sec()
 }
 
 
-configure_mac_sec
+configure_mac_sec $1 $2 $3 $4 $5 $6 $7 $8
 ip macsec show

--- a/socket/python3/main.py
+++ b/socket/python3/main.py
@@ -4,6 +4,7 @@ from mutauth import mutAuth
 from tools.monitoring_wpa import WPAMonitor
 from tools.utils import *
 from secure_channel.secchannel import SecMessageHandler
+from macsec import macsec
 
 shutdown_event = threading.Event()
 
@@ -25,7 +26,7 @@ def manage_server(mua):
     print("------------------server ---------------------")
     return mua.start_auth_server()
 
-
+"""
 def server_sechannel(serv, client):
     rand = generate_session_key()
     secchan = SecMessageHandler(serv.get_secure_socket(client))
@@ -34,6 +35,7 @@ def server_sechannel(serv, client):
     print(f"sending random value: {rand}")
     secchan.send_message(str(rand))
     return secchan, rand
+"""
 
 
 def manage_client(out_queue, mua):
@@ -41,15 +43,37 @@ def manage_client(out_queue, mua):
     print("------------------client ---------------------")
     time.sleep(3)
     if "_server" in message:
-        cli = mua.start_auth_client(message.split('_server')[0])
+        server_mac = message.split('_server')[0]
+    #TODO: check why client is starting even when message does not contain '_server'
     else:
-        cli = mua.start_auth_client(message)
-    cli.establish_connection()
+        server_mac = message
+    cli = mua.start_auth_client(server_mac)
+    cli.establish_connection() #TODO: check if secchan should be established only if server certificate is verified
+    setup_macsec_mesh(role="secondary",
+                      secure_client_socket=cli.secure_client_socket,
+                      my_mac=cli.mymac,
+                      client_mac=server_mac)
+    """
     client_secchan = SecMessageHandler(cli.secure_client_socket)
-    receiver_thread = threading.Thread(target=client_secchan.receive_message)
+    macsec_key_q = queue.Queue() # queue to store macsec_key from client_secchan.receive_message
+    receiver_thread = threading.Thread(target=client_secchan.receive_message, args=(macsec_key_q, ))
     receiver_thread.start()
-    return client_secchan
+    my_macsec_key = generate_session_key()
+    print(f"sending random value as my macsec key: {my_macsec_key}")
+    client_secchan.send_message(f"macsec_key_{str(my_macsec_key)}")
+    server_macsec_key = macsec_key_q.get()
+    print('Server macsec key: ', server_macsec_key)
+    # Initialize macsec object with macsec parameters
+    macsec_obj = macsec.Macsec(role="secondary",
+                               key1=server_macsec_key,
+                               key2=my_macsec_key,
+                               mac_prim=server_mac,
+                               mac_seco=cli.mymac)
+    macsec_obj.run_macsec()  # set macsec
+    batman_exec(routing_algo="batman-adv", wifidev="macsec0", ip_address=get_mesh_ipv6_from_conf_file(), prefixlen=32) # Execute batman
 
+    return client_secchan
+    """
 
 def main():
     in_queue = queue.Queue()
@@ -65,6 +89,8 @@ def main():
     wpa_thread.start()
     mutAuth_tread.start()
 
+    mutAuth_start_time = time.time() #TODO: remove later (this is only for test)
+
     # Flags to prevent multiple instances of server/client
     is_server_started = False
     is_client_started = False
@@ -75,20 +101,27 @@ def main():
         # If the node should be a server and hasn't already become one
         if mua.server_event.is_set() and not is_server_started and not is_client_started:
             print("Inside server event check")
+            print("Time taken for server to start = ", time.time() - mutAuth_start_time) #TODO: remove later (this is only for test)
             server_thread, serv = manage_server(mua)
+            # TODO trigger this when client thread ends -> not sure if we should call it from AuthServer
+            """
+            time.sleep(15)
+            print("Debug: client_auth_results: ", serv.client_auth_results)
             if serv.client_auth_results:
                 print(serv.client_auth_results)
                 for client in serv.client_auth_results:
                     return server_sechannel(serv, client)
+            """
             is_server_started = True
             mua.server_event.clear()  # Clearing the event to prevent re-entry
 
         # If the node shouldn't be a server and hasn't already become a client
         elif not mua.server and not is_client_started and not is_server_started and time.time() - wait_start >= server_wait_time:
             print("entering as client")
-            client_secchan = manage_client(out_queue, mua)
-            macsec_key = client_secchan.set_callback(on_message_received)
-            print(macsec_key)
+            print("Time taken for client to start = ", time.time() - mutAuth_start_time) #TODO: remove later (this is only for test)
+            manage_client(out_queue, mua)
+            #macsec_key = client_secchan.set_callback(on_message_received)
+            #print('Macsec key: ', macsec_key)
             is_client_started = True
 
         # If no decision can be made, we wait for a short period

--- a/socket/python3/main.py
+++ b/socket/python3/main.py
@@ -26,17 +26,6 @@ def manage_server(mua):
     print("------------------server ---------------------")
     return mua.start_auth_server()
 
-"""
-def server_sechannel(serv, client):
-    rand = generate_session_key()
-    secchan = SecMessageHandler(serv.get_secure_socket(client))
-    receiver_thread = threading.Thread(target=secchan.receive_message)
-    receiver_thread.start()
-    print(f"sending random value: {rand}")
-    secchan.send_message(str(rand))
-    return secchan, rand
-"""
-
 
 def manage_client(out_queue, mua):
     source, message = out_queue.get()
@@ -53,27 +42,6 @@ def manage_client(out_queue, mua):
                       secure_client_socket=cli.secure_client_socket,
                       my_mac=cli.mymac,
                       client_mac=server_mac)
-    """
-    client_secchan = SecMessageHandler(cli.secure_client_socket)
-    macsec_key_q = queue.Queue() # queue to store macsec_key from client_secchan.receive_message
-    receiver_thread = threading.Thread(target=client_secchan.receive_message, args=(macsec_key_q, ))
-    receiver_thread.start()
-    my_macsec_key = generate_session_key()
-    print(f"sending random value as my macsec key: {my_macsec_key}")
-    client_secchan.send_message(f"macsec_key_{str(my_macsec_key)}")
-    server_macsec_key = macsec_key_q.get()
-    print('Server macsec key: ', server_macsec_key)
-    # Initialize macsec object with macsec parameters
-    macsec_obj = macsec.Macsec(role="secondary",
-                               key1=server_macsec_key,
-                               key2=my_macsec_key,
-                               mac_prim=server_mac,
-                               mac_seco=cli.mymac)
-    macsec_obj.run_macsec()  # set macsec
-    batman_exec(routing_algo="batman-adv", wifidev="macsec0", ip_address=get_mesh_ipv6_from_conf_file(), prefixlen=32) # Execute batman
-
-    return client_secchan
-    """
 
 def main():
     in_queue = queue.Queue()
@@ -103,15 +71,6 @@ def main():
             print("Inside server event check")
             print("Time taken for server to start = ", time.time() - mutAuth_start_time) #TODO: remove later (this is only for test)
             server_thread, serv = manage_server(mua)
-            # TODO trigger this when client thread ends -> not sure if we should call it from AuthServer
-            """
-            time.sleep(15)
-            print("Debug: client_auth_results: ", serv.client_auth_results)
-            if serv.client_auth_results:
-                print(serv.client_auth_results)
-                for client in serv.client_auth_results:
-                    return server_sechannel(serv, client)
-            """
             is_server_started = True
             mua.server_event.clear()  # Clearing the event to prevent re-entry
 
@@ -150,7 +109,7 @@ TODO:
             # bio_read() and bio_write()
             # for using DTLS with Scapy instead of a socket
 5) generate session key (with XOR)
-7) test macsec
+7) test macsec 
 8) test batman_adv implementation
 9) ipsec
 

--- a/socket/python3/mutauth.py
+++ b/socket/python3/mutauth.py
@@ -125,7 +125,6 @@ class mutAuth():
                                 break  # break out of the waiting loop
                         except queue.Empty:
                             continue
-
                     if time.time() - last_received > TIMEOUT and not self.is_server_running:
                         try:
                             self.logger.info("Attempting to become a server.")
@@ -145,6 +144,7 @@ class mutAuth():
     def start_auth_client(self, ServerIP):
         return AuthClient(ServerIP, self.port, self.CERT_PATH)
 
+    """
     def macsec(self, mac_client, key1, key2):
         if self.server:
             role = "primary"
@@ -154,7 +154,7 @@ class mutAuth():
             set_macsec(role, self.meshiface, key2, key1, mac_client, self.mymac)
         # Call the function to run the bash script
         run_macsec(["up", self.meshiface, role])
-
+    """
     def batman(self):
         # todo check the interface
         ipv6 = mac_to_ipv6(self.meshiface)

--- a/socket/python3/secure_channel/secchannel.py
+++ b/socket/python3/secure_channel/secchannel.py
@@ -1,3 +1,4 @@
+import queue
 import ssl
 import socket
 from tools.custom_logger import CustomLogger
@@ -42,7 +43,7 @@ class SecMessageHandler:
         except Exception as e:
             self.logger.error("Error sending message.", exc_info=True)
 
-    def receive_message(self):
+    def receive_message(self, macsec_key_q=queue.Queue()):
         """Continuously receive messages from the socket."""
         if not self._is_ssl_socket():
             self.logger.error("Socket is not SSL enabled.")
@@ -61,6 +62,9 @@ class SecMessageHandler:
                     self.logger.info(f"Received: {data}")
                     if self.callback:
                         self.callback(data)  # Execute the callback with the received data
+                    if "macsec_key_" in data: # if received data is the macsec key, put it in queue
+                        macsec_key = data.split('macsec_key_')[1]
+                        macsec_key_q.put(macsec_key)
 
         except socket.timeout:
             self.logger.warning("Connection timed out. Ending communication.")

--- a/socket/python3/tools/utils.py
+++ b/socket/python3/tools/utils.py
@@ -322,6 +322,14 @@ def setup_macsec(role, my_macsec_key, client_macsec_key, my_mac, client_mac):
 def setup_macsec_mesh(role, secure_client_socket, my_mac, client_mac):
     # Setup macsec and batman
     secchan, my_macsec_key, client_macsec_key = setup_secchannel(secure_client_socket) # Establish secure channel and exchange macsec key
-    setup_macsec(role, my_macsec_key, client_macsec_key, my_mac, client_mac) #setup macsec
-    batman_exec(routing_algo="batman-adv", wifidev="macsec0", ip_address=get_mesh_ipv6_from_conf_file(), prefixlen=32)  # Execute batman
+    try:
+        setup_macsec(role, my_macsec_key, client_macsec_key, my_mac, client_mac) #setup macsec
+        logger.info(f'Macsec enabled with {client_mac}')
+    except Exception as e:
+        logger.error(f'Error setting up macsec with {client_mac}: {e}')
+    try:
+        batman_exec(routing_algo="batman-adv", wifidev="macsec0", ip_address=get_mesh_ipv6_from_conf_file(), prefixlen=32)  # Execute batman
+        logger.info('Batman executed')
+    except Exception as e:
+        logger.error(f'Error executing batman: {e}')
 

--- a/socket/python3/tools/utils.py
+++ b/socket/python3/tools/utils.py
@@ -8,9 +8,14 @@ import queue
 import socket
 import ipaddress
 from .custom_logger import CustomLogger
+import threading
+sys.path.insert(0, '../')
+from secure_channel.secchannel import SecMessageHandler
+from macsec import macsec
 
 logger_instance = CustomLogger("utils")
 logger = logger_instance.get_logger()
+script_dir = os.path.dirname(__file__) # path to tools directory
 
 class UniqueQueue:
     def __init__(self):
@@ -131,23 +136,6 @@ def modify_conf_file(conf_file_path, new_values):
         config.write(configfile)
 
 
-def set_macsec(role, mesh_iface, key1, key2, mac_server, mac_client):
-    conf_file_path = "../macsec/variables.conf"
-    new_values = {
-        'DEFAULT': {
-            'INTERFACE': mesh_iface,
-            'STATUS': 'up',
-            'ROLE': role,
-            'KEY1': key1,
-            'KEY2': key2,
-            'MACPRIM': mac_server,
-            'MACSECO': mac_client
-        }
-    }
-
-    modify_conf_file(conf_file_path, new_values)
-
-
 def run_macsec(args):
     try:
         # Replace 'run_macsec.sh' with the actual path to your bash script
@@ -157,17 +145,17 @@ def run_macsec(args):
         print(f"Error executing the script: {e}")
         sys.exit(1)
 
-def batman_exec(routing_algo, wifidev, ip_address, netmask):
+def batman_exec(routing_algo, wifidev, ip_address, prefixlen):
     if routing_algo != "batman-adv":
         #TODO here should be OLSR
         return
     try:
-        run_batman(wifidev, ip_address, netmask)
+        run_batman(wifidev, ip_address, prefixlen)
     except subprocess.CalledProcessError as e:
         print(f"Error: {e}")
 
 
-def run_batman(wifidev, ip_address, netmask):
+def run_batman(wifidev, ip_address, prefixlen):
     # Run the batctl if add command
     subprocess.run(["batctl", "if", "add", wifidev], check=True)
 
@@ -175,9 +163,17 @@ def run_batman(wifidev, ip_address, netmask):
     # Run the ifconfig bat0 up command
     subprocess.run(["ifconfig", "bat0", "up"], check=True)
 
+    # Delete ipv6 address automatically assigned from mac
+    command = ["ip", "-6", "addr", "show", "dev", "bat0"]
+    result = subprocess.run(command, capture_output=True, text=True, check=True)
+    old_ip = result.stdout.split('inet6 ')[1].split(' ')[0]
+    print("Deleting bat0 ipv6 address automatically assigned from mac..")
+    subprocess.run(["ip", "address", "del", old_ip, "dev", "bat0"], check=True)
+
     print("bat0 ip address..")
     # Run the ifconfig bat0 <ip_address> netmask <netmask> command
-    subprocess.run(["ifconfig", "bat0", ip_address, "netmask", netmask], check=True)
+    #subprocess.run(["ifconfig", "bat0", ip_address, "netmask", netmask], check=True)
+    subprocess.run(["ip", "-6", "addr", "add", f'{ip_address}/{prefixlen}', "dev", "bat0"], check=True)
 
     print("bat0 mtu size")
     # Run the ifconfig bat0 mtu 1460 command
@@ -279,5 +275,53 @@ def is_ipv6(ip):
         return False
 
 def generate_session_key():
-    rand = os.urandom(32)
-    return int.from_bytes(rand, 'big')
+    rand = os.urandom(16)
+    #return int.from_bytes(rand, 'big')
+    return rand.hex()
+
+def read_conf_file(conf_file_path):
+    # Create a configparser object
+    config = configparser.ConfigParser()
+    # Read the configuration file
+    config.read(conf_file_path)
+    return config
+
+def get_mesh_ipv6_from_conf_file():
+    conf_file_path = f'{script_dir}/../cert_generation/csr.conf'
+    config = read_conf_file(conf_file_path)
+    return config.get('alt_names', 'IP.2')
+
+def setup_secchannel(secure_client_socket):
+    # Establish secure channel and exchange macsec key
+    my_macsec_key = generate_session_key()
+    secchan = SecMessageHandler(secure_client_socket)
+    macsec_key_q = queue.Queue()  # queue to store macsec_key from client_secchan.receive_message
+    receiver_thread = threading.Thread(target=secchan.receive_message, args=(macsec_key_q,))
+    receiver_thread.start()
+    print(f"sending random value as my macsec key: {my_macsec_key}")
+    secchan.send_message(f"macsec_key_{str(my_macsec_key)}")
+    client_macsec_key = macsec_key_q.get()
+    return secchan, my_macsec_key, client_macsec_key
+
+def setup_macsec(role, my_macsec_key, client_macsec_key, my_mac, client_mac):
+    # Setup macsec parameters according to role
+    if role == "primary":
+        key1 = my_macsec_key
+        key2 = client_macsec_key
+        mac_prim = my_mac
+        mac_seco = client_mac
+    else:
+        key1 = client_macsec_key
+        key2 = my_macsec_key
+        mac_prim = client_mac
+        mac_seco = my_mac
+    # Initialize macsec object with macsec parameters
+    macsec_obj = macsec.Macsec(role, key1, key2, mac_prim, mac_seco)
+    macsec_obj.run_macsec()  # set macsec
+
+def setup_macsec_mesh(role, secure_client_socket, my_mac, client_mac):
+    # Setup macsec and batman
+    secchan, my_macsec_key, client_macsec_key = setup_secchannel(secure_client_socket) # Establish secure channel and exchange macsec key
+    setup_macsec(role, my_macsec_key, client_macsec_key, my_mac, client_mac) #setup macsec
+    batman_exec(routing_algo="batman-adv", wifidev="macsec0", ip_address=get_mesh_ipv6_from_conf_file(), prefixlen=32)  # Execute batman
+


### PR DESCRIPTION
* tools/utils.py -> Added functions setup_secchannel() to setup and exchange macsec keys (keys are prefixed with 'macsec_key_', setup_macsec() to configure macsec parameters, setup_macsec_mesh() to execute macsec and batman (ip for bat0 is taken from IP.2 field of csr.conf file)
* secure_channel.py -> Puts macsec key received to a queue so that it can be popped while executing macsec
* setmacsec.sh -> Script takes these parameters as input: <interface> <up/down> <encryption on/off> <primary/secondary> <key1> <key2> <mac primary> <mac secondary> instead of reading it from variables.conf
* macsec.py -> Class to configure macsec parameters and execute setmacsec.sh
* authServer.py -> call utils.setup_macsec_mesh() once client is authenticated
* main.py -> call utils.setup_macsec_mesh() from manage_client once connection is established