### PR TITLE
Added multicast over bat0, setup upper macsec and bat1

### DIFF
--- a/socket/python3/auth/authClient.py
+++ b/socket/python3/auth/authClient.py
@@ -17,11 +17,11 @@ MAX_WAIT_TIME = 3  # seconds
 
 
 class AuthClient:
-    def __init__(self, server_mac, server_port, cert_path, mua):
+    def __init__(self, interface, server_mac, server_port, cert_path, mua):
         self.sslServerIP = mac_to_ipv6(server_mac)
         self.sslServerPort = server_port
         self.CERT_PATH = cert_path
-        self.interface = "wlp1s0"
+        self.interface = interface
         self.secure_client_socket = None
         self.logger = self._setup_logger()
         self.ca = f'{self.CERT_PATH}/ca.crt'

--- a/socket/python3/auth/authServer.py
+++ b/socket/python3/auth/authServer.py
@@ -15,14 +15,14 @@ logger = logger_instance.get_logger()
 
 
 class AuthServer:
-    def __init__(self, ip_address, port, cert_path, mua):
+    def __init__(self, interface, ip_address, port, cert_path, mua):
         threading.Thread.__init__(self)
         self.running = True
         self.ipAddress = ip_address
         self.port = port
         self.CERT_PATH = cert_path
         self.ca = f'{self.CERT_PATH}/ca.crt'
-        self.interface = "wlp1s0"
+        self.interface = interface
         self.mymac = get_mac_addr(self.interface)
         # Create the SSL context here and set it as an instance variable
         self.context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)

--- a/socket/python3/main.py
+++ b/socket/python3/main.py
@@ -5,10 +5,9 @@ from tools.monitoring_wpa import WPAMonitor
 from tools.utils import *
 from secure_channel.secchannel import SecMessageHandler
 from macsec import macsec
-
 shutdown_event = threading.Event()
 
-
+"""
 def signal_handler(sig, frame):
     print("\nCaught signal. Shutting down gracefully...")
     shutdown_event.set()
@@ -40,29 +39,49 @@ def manage_client(out_queue, mua):
     cli.establish_connection() #TODO: check if secchan should be established only if server certificate is verified
     mua.setup_macsec(secure_client_socket=cli.secure_client_socket,
                      client_mac=server_mac)
-
+"""
 def start_up(mua):
     # Sets up wlp1s0 interface
     mua.check_mesh()
 
-def mutual_authentication(mua, in_queue):
+def mutual_authentication_lower(mua, in_queue):
     # Start server to facilitate client auth requests, monitor ongoing auths and start client request if there is a new peer/ server baecon
     auth_server_thread, auth_server = mua.start_auth_server()
     # Start monitoring wpa for new peer connection
     wpa_ctrl_instance = WPAMonitor(mua.wpa_supplicant_ctrl_path)
     wpa_thread = threading.Thread(target=wpa_ctrl_instance.start_monitoring, args=(in_queue,))
-    mutAuth_tread = threading.Thread(target=mua.monitor_wpa)
+    monitor_thread = threading.Thread(target=mua.monitor_wpa_multicast)
     wpa_thread.start()
-    mutAuth_tread.start()
+    monitor_thread.start()
+
+def mutual_authentication_upper(mua, in_queue):
+    # Wait for bat0 to be pingable before starting mtls server, multicast
+    wait_for_interface_to_be_pingable(mua.meshiface, mua.ipAddress)
+    # Start server to facilitate client auth requests, monitor ongoing auths and start client request if there is a new peer/ server baecon
+    auth_server_thread, auth_server = mua.start_auth_server()
+    # Start multicast receiver that listens to multicasts from other mesh nodes
+    receiver_thread = threading.Thread(target=mua.multicast_handler.receive_multicast)
+    monitor_thread = threading.Thread(target=mua.monitor_wpa_multicast)
+    receiver_thread.start()
+    monitor_thread.start()
+    # Send periodic multicasts
+    mua.sender_thread.start()
 
 def main():
-    in_queue = queue.Queue()
-    out_queue = queue.Queue()
+    in_queue_lower = queue.Queue()
+    out_queue_lower = queue.Queue()
+    lower_batman_setup_event = threading.Event() # Event that notifies that lower macsec and bat0 has been setup
+    mua_lower = mutAuth(in_queue_lower, out_queue_lower, level="lower", meshiface="wlp1s0", port=15001, batman_interface="bat0", shutdown_event=shutdown_event, batman_setup_event=lower_batman_setup_event)
+    start_up(mua_lower)
+    mutual_authentication_lower(mua_lower, in_queue_lower)
 
-    mua = mutAuth(in_queue, out_queue, shutdown_event)
-    start_up(mua)
-    mutual_authentication(mua, in_queue)
-
+    # Wait till lower batman is set to start mutauth for upper macsec
+    lower_batman_setup_event.wait()
+    in_queue_upper = queue.Queue()
+    out_queue_upper = queue.Queue()
+    upper_batman_setup_event = threading.Event()  # Event that notifies that upper macsec and bat1 has been setup
+    mua_upper = mutAuth(in_queue_upper, out_queue_upper, level="upper", meshiface="bat0", port=15002, batman_interface="bat1", shutdown_event=shutdown_event, batman_setup_event=upper_batman_setup_event)
+    mutual_authentication_upper(mua_upper, in_queue_upper)
 """
 def main():
     in_queue = queue.Queue()

--- a/socket/python3/tools/utils.py
+++ b/socket/python3/tools/utils.py
@@ -311,3 +311,10 @@ def add_interface_to_batman(interface_to_add, batman_interface):
         logger.info(f'Added interface {interface_to_add} to {batman_interface}')
     except Exception as e:
         logger.error(f'Error adding interface {interface_to_add} to {batman_interface}: {e}')
+
+def add_interface_to_bridge(interface_to_add, bridge_interface):
+    try:
+        subprocess.run(["brctl", "addif", bridge_interface, interface_to_add], check=True)
+        logger.info(f'Added interface {interface_to_add} to {bridge_interface}')
+    except Exception as e:
+        logger.error(f'Error adding interface {interface_to_add} to {bridge_interface}: {e}')


### PR DESCRIPTION
Flow:
1) Monitor peer connected event on wlp1s0 (we can add multicast beacons over wlp1s0 too) 
2) mTLS over wlp1s0 and exchange lower macsec parameters 
3) Setup lower macsec and add it to lower batman (bat0) 
4) Send and receive multicast baecons for upper macsec over bat0 
5) mTLS over bat0 and exchange upper macsec parameters 
6) Add upper macsec interfaces to a bridge (br-upper) 
7) Set upper batman (bat1) over br-upper